### PR TITLE
Update 2012-03-31-siq-reverse-dll.rkt

### DIFF
--- a/posts/2012-03-31-siq-reverse-dll.rkt
+++ b/posts/2012-03-31-siq-reverse-dll.rkt
@@ -93,7 +93,7 @@ the way, this assumes we have this definition of doubly-linked-lists:
          (when head
            (set-node-last! head new))
          (unless (dll-tail l)
-           (set-dll-tail! l new))
+           (set-dll-tail! l head))
          (set-dll-head! l new))
        (define dll-cons! 
          (make-dll-cons!


### PR DESCRIPTION
original doesn't update the dll tail to correct value when consing onto dll with no tail (i.e. (dll any #f))
